### PR TITLE
add Fedora ARM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@ $ curl -o termux-setup.sh https://raw.githubusercontent.com/egandro/docker-qemu-
 ```
 
 
-## Raspberry Pi
+## Raspberry Pi OS
 
 
 ```bash
 $ curl -o pi-setup.sh https://raw.githubusercontent.com/egandro/docker-qemu-arm/master/pi-setup.sh && chmod 755 ./pi-setup.sh && ./pi-setup.sh
 ```
+
+##  Fedora ARM
+
+```bash
+$ curl -o fedora-arm-setup.sh https://raw.githubusercontent.com/egandro/docker-qemu-arm/master/fedora-arm-setup.sh && chmod 755 ./fedora-arm-setup.sh && ./fedora-arm-setup.sh
+```
+
 
 ## Postinstall & fun
 

--- a/fedora-arm-setup.sh
+++ b/fedora-arm-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sudo dnf install -y qemu-system-x86-core edk2-ovmf expect wget
+
+mkdir -p alpine
+cd alpine
+wget -q -c -t0 https://raw.githubusercontent.com/egandro/docker-qemu-arm/master/ssh2qemu.sh
+chmod +x ./ssh2qemu.sh
+wget -q -c -t0 https://raw.githubusercontent.com/egandro/docker-qemu-arm/master/startqemu.sh
+chmod +x ./startqemu.sh
+sed -i "s:\$PREFIX/share/qemu/edk2-x86_64-code.fd:/usr/share/edk2/ovmf/OVMF_CODE.fd:g" ./startqemu.sh
+wget -q -c -t0 https://raw.githubusercontent.com/egandro/docker-qemu-arm/master/installqemu.expect
+sed -i "s:\$env(PREFIX)/share/qemu/edk2-x86_64-code.fd:/usr/share/edk2/ovmf/OVMF_CODE.fd:g" ./installqemu.expect
+expect -f installqemu.expect


### PR DESCRIPTION
Changes:
- EFI image is located as `/usr/share/edk2/ovmf/OVMF_CODE.fd` in Fedora.
- Create install requirements for Fedora.
- Update `README.md` for last changes.